### PR TITLE
don't clear if jshint is disabled

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -84,6 +84,10 @@ endif
 
 
 function! s:JSHintClear()
+  if exists("b:jshint_disabled") && b:jshint_disabled == 1
+    return
+  endif
+    
   " Delete previous matches
   let s:matches = getmatches()
   for s:matchId in s:matches


### PR DESCRIPTION
this just checks if the user has disabled jshint with `:JSHintToggle` before executing the main body of `s:JSHintClear()`.

this is important for other plugins that need to be able to temporarily disable jshint for performance sake (i.e. scripts that frequently switch between windows), but don't want to lose the saved state.
