### PR TITLE
Check for a .jshintrc relative to the current file being worked on

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -63,12 +63,30 @@ if has('win32')
 endif
 let s:cmd = "cd " . s:plugin_path . " && node " . s:plugin_path . "runner.js"
 
-let s:jshintrc_file = expand('~/.jshintrc')
-if filereadable(s:jshintrc_file)
-  let s:jshintrc = readfile(s:jshintrc_file)
-else
-  let s:jshintrc = []
-end
+" FindRc() will try to find a .jshintrc up the current path string
+" If it cannot find one it will try looking in the home directory
+" finally it will return an empty list indicating jshint should use
+" the defaults.
+if !exists("*s:FindRc")
+  function s:FindRc(path)
+    let l:filename = '/.jshintrc'
+    let l:jshintrc_file = expand(a:path) . l:filename
+    if filereadable(l:jshintrc_file)
+      let s:jshintrc = [join(readfile(l:jshintrc_file), '')]
+    elseif len(a:path) > 1
+      call s:FindRc(fnamemodify(expand(a:path), ":h"))
+    else 
+      let s:jshintrc_file = expand('~') . l:filename
+      if filereadable(l:jshintrc_file)
+        let s:jshintrc = [join(readfile(l:jshintrc_file), '')]
+      else
+        let s:jshintrc = []
+      end
+    endif
+  endfun
+endif
+
+call s:FindRc(expand("%:p:h"))
 
 " WideMsg() prints [long] message up to (&columns-1) length
 " guaranteed without "Press Enter" prompt.
@@ -81,7 +99,6 @@ if !exists("*s:WideMsg")
     let &ruler=x | let &showcmd=y
   endfun
 endif
-
 
 function! s:JSHintClear()
   if exists("b:jshint_disabled") && b:jshint_disabled == 1


### PR DESCRIPTION
Hallet's jslint vim plugin will check the current working directory for a `.jslintrc` file before defaulting to `~/.jslintrc`. I wanted to take it one step further and have this plugin start at the current file's working directory and walk up the directory tree looking for a `.jshintrc`, which would presumably be in the project's root but could also have special files in subdirectories (e.g., different `.jshintrc` files for client side and server side javascript)

Along the way I noticed that if you want to make your `.jshintrc` a little more readable by separating out into multiple lines it will work but it will also generate an error. I've also fixed that issue by converting the `.jshintrc` into a single line after reading it into the plugin.
- Walks up directory tree from the current file's location
  - If not found, it will default to `~/.jshintrc`
  - If not found, use module's defaults
- Fixed issue that prevented having .jshintrc in multiple lines
