### PR TITLE
Fix some bugs with the comment handling.

### DIFF
--- a/ftplugin/javascript/jshint/runner.js
+++ b/ftplugin/javascript/jshint/runner.js
@@ -9,6 +9,9 @@ function allcomments(s) {
   return /^(?:\s*\/\/[^\n]*\s*|\s*\/\*(?:[^\*]|\*(?!\/))*\*\/\s*)*$/.test(s);
 }
 
+// This function will produce incorrect results for certain pathological
+// expressions involving regexp literals. This is okay, since it's only meant
+// to be used on JSON-with-comments, and JSON doesn't have regexp literals.
 function removecomments(s) {
   var re = /(["'])(?:[^\1]|\\\1|)*\1|\/\/[^\n]*|\/\*(?:[^\*]|\*(?!\/))*\*\//g;
   return s.replace(re, function(x) {


### PR DESCRIPTION
Some bugfixes for my previous pull request.

Amazingly, I actually did test that previous code, but clearly I wasn't thorough enough about it. Sorry about that. Here's a slightly more comprehensive test:

<!-- { -->

``` bash
# run from the root of the working directory.
sed -ne '/function [a-z]\+comments/,/^}/p' \
  ftplugin/javascript/jshint/runner.js \
  > test-comment-handling.js
cat >> test-comment-handling.js <<"END"
var tests = [
  // should be allcomments
  '// 1\n// 2',
  '/* 1 **//*jshint 2*/\n/** /* 3 */',
  '  //\n//// \n/*\n"// " */',
  // should not be allcomments
  '/**//\n//* 1\n2 *// 2',
  '//* 1\n"/* should not be removed */"// 2 /* */ 2',
  '/* 1 */"// should not be removed"/* 2 */',
  '4/* 1 */2/*jshint 2*/question\n/* 3 */answer'
];
tests.forEach(function(x) {
  if (allcomments(x)) {
    console.log('allcomments');
  }
  console.log('[%s]', removecomments(x));
});
END

node test-comment-handling.js
```
