### PR TITLE
Correctly store and pass the jshintrc filename into runner.js

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -72,15 +72,15 @@ if !exists("*s:FindRc")
     let l:filename = '/.jshintrc'
     let l:jshintrc_file = expand(a:path) . l:filename
     if filereadable(l:jshintrc_file)
-      let s:jshintrc = [join(readfile(l:jshintrc_file), '')]
+      let s:jshintrc_file = l:jshintrc_file
     elseif len(a:path) > 1
       call s:FindRc(fnamemodify(expand(a:path), ":h"))
     else 
-      let s:jshintrc_file = expand('~') . l:filename
+      let l:jshintrc_file = expand('~') . l:filename
       if filereadable(l:jshintrc_file)
-        let s:jshintrc = [join(readfile(l:jshintrc_file), '')]
+        let s:jshintrc_file = l:jshintrc_file
       else
-        let s:jshintrc = []
+        let s:jshintrc_file = ''
       end
     endif
   endfun
@@ -156,7 +156,7 @@ function! s:JSHint()
     return
   endif
 
-  let b:jshint_output = system(s:cmd, lines . "\n")
+  let b:jshint_output = system(s:cmd . " " . s:jshintrc_file, lines . "\n")
   if v:shell_error
     echoerr 'could not invoke JSHint!'
     let b:jshint_disabled = 1


### PR DESCRIPTION
Previously, `s:FindRc` was storing a list of a string containing the contents of a .jshintrc in `s:jshintrc` -- this was never used elsewhere. The argument wasn't being passed into `runner.js`, which accepts a filename anyway, not a string of the contents.

This fixed using a .jshintrc file anywhere in the upward directory path for me, but I could very well be doing it completely wrong, and VIMScript is horrifying so there's probably a better way to write it. :icecream: 
