### PR TITLE
Run only on write

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -15,10 +15,18 @@ endif
 
 let s:install_dir = expand('<sfile>:p:h')
 
-" Only check on saving
-" au BufLeave <buffer> call s:JSHintClear()
-" au BufEnter <buffer> call s:JSHint()
-" au InsertLeave <buffer> call s:JSHint()
+au BufLeave <buffer> call s:JSHintClear()
+
+" Find out when JSHint should update
+
+if !exists("g:JSHintUpdateWriteOnly")
+  let g:JSHintUpdateWriteOnly = 0
+endif
+
+if g:JSHintUpdateWriteOnly == 0
+  au BufEnter <buffer> call s:JSHint()
+  au InsertLeave <buffer> call s:JSHint()
+endif
 
 "au InsertEnter <buffer> call s:JSHint()
 au BufWritePost <buffer> call s:JSHint()


### PR DESCRIPTION
When having JSHint installed, vim-multiple cursors gets very slow when in inserting in several places simultaneously. It seems for every character you type, JSHint is called to lint the entire document. This leads to severe lag.

I guess this might have more to do with the implementation of vim-multiple-cursos than JSHint.vim, but still, wanting to use them both, I thought it would be easier to make a small change to the latter than the former. I introduced a new global that allows allows one to only run JSHint when writing. For me that's a good trade-off and it seems to work ok, so I wanted to share.

I'm pretty new to both vimscript and github pull requests, so please let me know if I'm doing it wrong and I'll learn. Worst case scenario, I'll keep maintaining my own fork.
