### PR TITLE
Run only on write

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -15,10 +15,18 @@ endif
 
 let s:install_dir = expand('<sfile>:p:h')
 
-" Only check on saving
-" au BufLeave <buffer> call s:JSHintClear()
-" au BufEnter <buffer> call s:JSHint()
-" au InsertLeave <buffer> call s:JSHint()
+au BufLeave <buffer> call s:JSHintClear()
+
+" Find out when JSHint should update
+
+if !exists("g:JSHintUpdateWriteOnly")
+  let g:JSHintUpdateWriteOnly = 0
+endif
+
+if g:JSHintUpdateWriteOnly == 0
+  au BufEnter <buffer> call s:JSHint()
+  au InsertLeave <buffer> call s:JSHint()
+endif
 
 "au InsertEnter <buffer> call s:JSHint()
 au BufWritePost <buffer> call s:JSHint()


### PR DESCRIPTION
jshint.vim and vim-multiple-cursors don't play nice together. When I'm inserting in several places at once, vim comes crawling to a halt. It seems that after every character I type, the entire document is linted.

This might have more to do with the inner workings of vim-multiple-cursors than it does with jshint.vim. Still, I want to use both plugins, and building a solution into jshint.vim seemed easier. I have included a global that, when set, only runs JSHint when writing. For me this is a good trade-off that solves the problem.

Considering others might have the same problem, I want to share my solution. I'm new to both vimscript and github pull requests, so please let me know if I'm doing something wrong. If it is felt that this change doesn't belong in the original repository, that's fine by me too, I'll just maintain my fork.
