### PR TITLE
Resolves issues with windows root paths and paths with spaces.

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -61,7 +61,7 @@ let s:plugin_path = s:install_dir . "/jshint/"
 if has('win32')
   let s:plugin_path = substitute(s:plugin_path, '/', '\', 'g')
 endif
-let s:cmd = "cd " . s:plugin_path . " && node " . s:plugin_path . "runner.js"
+let s:cmd = 'cd "' . s:plugin_path . '" && node "' . s:plugin_path . 'runner.js"'
 
 " FindRc() will try to find a .jshintrc up the current path string
 " If it cannot find one it will try looking in the home directory
@@ -71,10 +71,11 @@ if !exists("*s:FindRc")
   function s:FindRc(path)
     let l:filename = '/.jshintrc'
     let l:jshintrc_file = expand(a:path) . l:filename
+    let l:path_head = fnamemodify(expand(a:path), ":h")
     if filereadable(l:jshintrc_file)
       let s:jshintrc_file = l:jshintrc_file
-    elseif len(a:path) > 1
-      call s:FindRc(fnamemodify(expand(a:path), ":h"))
+    elseif a:path != l:path_head
+      call s:FindRc(l:path_head)
     else
       let l:jshintrc_file = expand('~') . l:filename
       if filereadable(l:jshintrc_file)
@@ -156,7 +157,7 @@ function! s:JSHint()
     return
   endif
 
-  let b:jshint_output = system(s:cmd . " " . s:jshintrc_file, lines . "\n")
+  let b:jshint_output = system(s:cmd . ' "' . s:jshintrc_file . '"', lines . "\n")
   if v:shell_error
     echoerr 'could not invoke JSHint!'
     let b:jshint_disabled = 1


### PR DESCRIPTION
Resolves #16. This should fix the Windows issues by adding support for Windows root paths. Vim sees a Windows root path as "C:\" so the length comparison to 1 had to be changed. I also added support for spaces within the paths.

I've tested this on Windows XP, Windows 7, OSX 10.8.5, and a recent version of Arch Linux and it looks like it hasn't broken anything. Let me know if you see any issues or would like any changes. Thanks!
