### PR TITLE
Adds node stack trace to default node jshint error message

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -167,7 +167,8 @@ function! s:JSHint()
 
   let b:jshint_output = system(s:cmd . " " . s:jshintrc_file, lines . "\n")
   if v:shell_error
-    echoerr 'could not invoke JSHint!'
+    echoerr 'could not invoke JSHint: '
+    echom b:jshint_output
     let b:jshint_disabled = 1
   end
 


### PR DESCRIPTION
Adds the node stack trace to the error message displayed in vim when something goes wrong with the node jshint process. This is intended to more easily diagnose and help resolve issues like #24. 
