### PR TITLE
Prevent jshinting of vim-fugitive buffers

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -14,7 +14,7 @@ else
 endif
 
 " Bail out for vim-fugitive file paths...
-if strridx(expand("%:p"), "fugitive") == 0
+if stridx(expand("%:p"), "fugitive:///") == 0
   finish
 endif
 


### PR DESCRIPTION
Currently jshint.vim doesn't play nicely with [tpope/vim-fugitive](https://github.com/tpope/vim-fugitive) when viewing diffs or previous versions of a file.  Vim-fugitive opens up these previous versions of files using a buffer path that looks like `fugitive:///path/to/repo/.git//0/src/file.js`. This causes some unexpected behaviour when walking up the directories looking for the .jshintrc file since the components of this path can't be found by vim. What usually ends up happening is the home folder's .jshintrc file will be used. If the project has a specific .jshintrc file, this causes different linting rules to be run on the vim-fugitive buffer than on the current version of the file.

I'm not really sure how to most elegantly handle this situation. I'm thinking that people may not need linting when viewing previous versions of their files, especially linting that is likely not configured for their project, so this commit prevents that from happening. If that's not the case, another option would be to try to reassemble the path to try to find a project specific .jshintrc file.
