### PR TITLE
Fix reading jshintrc files with comments in them.

### DIFF
--- a/ftplugin/javascript/jshint/runner.js
+++ b/ftplugin/javascript/jshint/runner.js
@@ -15,7 +15,7 @@ function allcomments(s) {
 // expressions involving regexp literals. This is okay, since it's only meant
 // to be used on JSON-with-comments, and JSON doesn't have regexp literals.
 function removecomments(s) {
-  var re = /(["'])(?:[^\1]|\\\1|)*\1|\/\/[^\n]*|\/\*(?:[^\*]|\*(?!\/))*\*\//g;
+  var re = /("([^"]|\\")*")|('([^']|\\')*')|\/\/[^\n]*|\/\*(?:[^\*]|\*(?!\/))*\*\//g;
   return s.replace(re, function(x) {
     return (/^["']/).test(x) ? x : ' ';
   });


### PR DESCRIPTION
This was failing with the [jshintrc file from the charlatan library](https://github.com/nodeca/charlatan/blob/3a838a7fb16605ca358b0baa4c31a5bda293cd9e/.jshintrc). Backreferences do not seem to work in character classes, so we can't collapse single and double quotes into a single test. This commit splits them out to work separately.

``` js
> /(a)[^\1]/.test('aa')
true
> /(a)[^\1]/.test('ab')
true
> /(a)[^\1]/.test('a\u0001')
false
```

In the above example the first line should have returned false if backreferences worked in character classes, but it did not. The second example works as you'd think, but for the wrong reason. The third example shows what's really going on. Rather than being treated as a backreference, `\1` is being interpreted as the character code 1.
