### PR TITLE
Fix issue with finding path to .jshintrc

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -1,4 +1,3 @@
-
 " Global Options
 "
 " Enable/Disable highlighting of errors in source.
@@ -83,7 +82,7 @@ if !exists("*s:FindRc")
     if filereadable(l:jshintrc_file)
       let s:jshintrc_file = l:jshintrc_file
     elseif len(a:path) > 1
-      call s:FindRc(fnamemodify(a:path, ":h:h"))
+      call s:FindRc(fnamemodify(a:path, ":h"))
     else
       let l:jshintrc_file = expand('~') . l:filename
       if filereadable(l:jshintrc_file)


### PR DESCRIPTION
On Windows 7, this script was climbing the directory tree 2 nodes at a time on its search for my .jshintrc (stored in my home directory under C:\Users\myusername).  If I was in a directory that was nested by an odd number of children, the rc would never get found.

I have not tested this patch in a unix environment
