### PR TITLE
Pass globals to jshint.

### DIFF
--- a/ftplugin/javascript/jshint/runner.js
+++ b/ftplugin/javascript/jshint/runner.js
@@ -46,7 +46,14 @@ stdin.on('end', function() {
     }
   }
 
-  if( jshint( prefix + body.join(''), options ) ){
+  var globals;
+
+  if (options && options.globals) {
+    globals = options.globals;
+    delete options.globals;
+  }
+
+  if( jshint( prefix + body.join(''), options, globals ) ){
     return;
   }
 


### PR DESCRIPTION
JSHINT requires you pass globals as the third argument.  Copied
this pattern from the src/cli.js from jshint itself:

https://github.com/jshint/jshint/blob/2.x/src/cli.js#L437
