### PR TITLE
JSHint plugin should populate Vim's location list instead of quick fix list

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -148,8 +148,8 @@ function! s:JSHint()
     let b:lastline = a:lastline
   endif
 
-  let b:qf_list = []
-  let b:qf_window_count = -1
+  let b:loc_list = []
+  let b:loc_window_count = -1
 
   let lines = join(getline(b:firstline, b:lastline), "\n")
   if len(lines) == 0
@@ -181,27 +181,27 @@ function! s:JSHint()
       " Add line to match list
       call add(b:matched, s:matchDict)
 
-      " Store the error for the quickfix window
-      let l:qf_item = {}
-      let l:qf_item.bufnr = bufnr('%')
-      let l:qf_item.filename = expand('%')
-      let l:qf_item.lnum = l:line
-      let l:qf_item.text = l:errorMessage
-      let l:qf_item.type = l:errorType
+      " Store the error for the location window
+      let l:loc_item = {}
+      let l:loc_item.bufnr = bufnr('%')
+      let l:loc_item.filename = expand('%')
+      let l:loc_item.lnum = l:line
+      let l:loc_item.text = l:errorMessage
+      let l:loc_item.type = l:errorType
 
-      " Add line to quickfix list
-      call add(b:qf_list, l:qf_item)
+      " Add line to location list
+      call add(b:loc_list, l:loc_item)
     endif
   endfor
 
-  if exists("s:jshint_qf")
-    " if jshint quickfix window is already created, reuse it
-    call s:ActivateJSHintQuickFixWindow()
-    call setloclist(0, b:qf_list, 'r')
+  if exists("s:jshint_loc")
+    " if jshint location window is already created, reuse it
+    call s:ActivateJSHintLocationWindow()
+    call setloclist(0, b:loc_list, 'r')
   else
-    " one jshint quickfix window for all buffers
-    call setloclist(0, b:qf_list, '')
-    let s:jshint_qf = s:GetQuickFixStackCount()
+    " one jshint location window for all buffers
+    call setloclist(0, b:loc_list, '')
+    let s:jshint_loc = s:GetLocationStackCount()
   endif
   let b:cleared = 0
 endfunction
@@ -231,12 +231,13 @@ if !exists("*s:GetJSHintMessage")
   endfunction
 endif
 
-if !exists("*s:GetQuickFixStackCount")
-    function s:GetQuickFixStackCount()
+if !exists("*s:GetLocationStackCount")
+    function s:GetLocationStackCount()
         let l:stack_count = 0
         try
             silent lolder 9
         catch /E380:/
+        catch /E776:/
         endtry
 
         try
@@ -245,27 +246,27 @@ if !exists("*s:GetQuickFixStackCount")
                 let l:stack_count = l:stack_count + 1
             endfor
         catch /E381:/
+        catch /E776:/
             return l:stack_count
         endtry
     endfunction
 endif
 
-if !exists("*s:ActivateJSHintQuickFixWindow")
-    function s:ActivateJSHintQuickFixWindow()
+if !exists("*s:ActivateJSHintLocationWindow")
+    function s:ActivateJSHintLocationWindow()
         try
-            silent lolder 9 " go to the bottom of quickfix stack
+            silent lolder 9 " go to the bottom of location stack
         catch /E380:/
         catch /E776:/
         endtry
 
-        if s:jshint_qf > 0
+        if s:jshint_loc > 0
             try
-                exe "silent lnewer " . s:jshint_qf
+                exe "silent lnewer " . s:jshint_loc
             catch /E381:/
+            catch /E776:/
                 echoerr "Could not activate JSHint Quickfix Window."
             endtry
         endif
     endfunction
 endif
-
-


### PR DESCRIPTION
While linting a js file with JSHint, it makes more sense to use the location list instead of the quick fix window.

One scenario that illustrates this is when users grep for some pattern within their project files, using a different plugin that populates the quick fix list with results. When the quick fix window pops up, the user will select a result from the list and jump directly to that result in another file. If that file happens to be a javascript file, the JSHint plugin lints the file automatically once the buffer is fully read. This action overwrites the contents of the quick fix window that contained the grep results, forcing the user to grep again, which is inconvenient.

Using the location list for linting prevents interference with quick fix enhanced greping, and other actions that are concerned with listing locations from multiple files (compiling, etc.). Besides, when you are linting in an editor, you're usually only concerned with the contents of that particular file.
