### PR TITLE
Update vundle commands in readme file.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,13 +17,13 @@ If you're old school or not into pathogen, there is a Makefile to copy everythin
 
 Add to vimrc:
 
-`Bundle "wookiehangover/jshint.vim"`
+`Plugin "wookiehangover/jshint.vim"`
 
 And install it:
 
 ```vim
 :so ~/.vimrc
-:BundleInstall
+:PluginInstall
 ```
 
 ### Install with [pathogen](https://github.com/tpope/vim-pathogen)


### PR DESCRIPTION
According to [vundle's changing interface](https://github.com/gmarik/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L372-L396), `Bundle` commands will be deprecated. I updated the readme file with `Plugin` command.