### PR TITLE
Replace 'Bundle' with 'Plugin' in Vundle instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,13 +17,13 @@ If you're old school or not into pathogen, there is a Makefile to copy everythin
 
 Add to vimrc:
 
-`Bundle "wookiehangover/jshint.vim"`
+`Plugin "wookiehangover/jshint.vim"`
 
 And install it:
 
 ```vim
 :so ~/.vimrc
-:BundleInstall
+:PluginInstall
 ```
 
 ### Install with [pathogen](https://github.com/tpope/vim-pathogen)


### PR DESCRIPTION
'Bundle' name is deprecated since April 2014 - https://github.com/gmarik/Vundle.vim/blob/8db3bcb5921103f0eb6de361c8b25cc03cb350b5/doc/vundle.txt#L372.