### PR TITLE
Fix .jshintrc location logic

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -83,7 +83,7 @@ let s:cmd = "cd " . s:plugin_path . " && ./runner.js"
 if !exists("*s:FindRc")
   function s:FindRc(path)
     let l:filename = '/.jshintrc'
-    let l:jshintrc_file = fnamemodify('.jshintrc', ':p')
+    let l:jshintrc_file = a:path . '/.jshintrc'
     if filereadable(l:jshintrc_file)
       let s:jshintrc_file = l:jshintrc_file
     elseif len(a:path) > 1


### PR DESCRIPTION
The code to look for .jshintrc intended to start from the current file's
directory and walk up on the filesystem until a .jshintrc was found.
Unfortunately this code was only ever looking at the current directory
and not really recursing up. Fix is to actually use the path passed to
FindRC().