### PR TITLE
Add quotes to jshint cd <dir> command

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -74,7 +74,7 @@ let s:plugin_path = s:install_dir . "/jshint/"
 if has('win32')
   let s:plugin_path = substitute(s:plugin_path, '/', '\', 'g')
 endif
-let s:cmd = "cd " . s:plugin_path . " && ./runner.js"
+let s:cmd = "cd \"" . s:plugin_path . "\" && ./runner.js"
 
 " FindRc() will try to find a .jshintrc up the current path string
 " If it cannot find one it will try looking in the home directory


### PR DESCRIPTION
My .vim resides in a path that has a space character in it, and the way jshint is being invoked breaks because of this.

I've added quotes in the right place to s:cmd so that things work for me. Maybe it'll help other people as well.