### PR TITLE
Fixes Error detected while processing function <SNR>38_JSHint: line 84: E927: Invalid action: ''

### DIFF
--- a/ftplugin/javascript/jshint.vim
+++ b/ftplugin/javascript/jshint.vim
@@ -216,7 +216,7 @@ function! s:JSHint()
     call setqflist(b:qf_list, 'r')
   else
     " one jshint quickfix window for all buffers
-    call setqflist(b:qf_list, '')
+    call setqflist(b:qf_list, ' ')
     let s:jshint_qf = s:GetQuickFixStackCount()
   endif
   let b:cleared = 0


### PR DESCRIPTION
Add space to `call setqflist(b:qf_list, '')`
Fixes Error detected while processing function <SNR>38_JSHint: line 84: E927: Invalid action: ''

I think this change was fixed in the past, but the current version sets off an error on my system without the addition of this space. See Issue #58 