### PR TITLE
Replacing " with '

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ If you're old school or not into pathogen, there is a Makefile to copy everythin
 
 Add to vimrc:
 
-`Plugin "wookiehangover/jshint.vim"`
+`Plugin 'wookiehangover/jshint.vim'`
 
 And install it:
 


### PR DESCRIPTION
VIM throw an error with double quotes, replaced them with single quotes:

Error detected while processing /Users/federicoulfo/.vimrc:
line   13:
E471: Argument required: Plugin